### PR TITLE
 Added support for 'uses' directives in generated the module-info.java

### DIFF
--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
@@ -331,6 +331,9 @@ abstract public class ExtraJavaModuleInfoTransform implements TransformAction<Ex
         for (String requireName : moduleInfo.requiresStatic) {
             moduleVisitor.visitRequire(requireName, Opcodes.ACC_STATIC_PHASE, null);
         }
+        for (String usesName : moduleInfo.uses) {
+            moduleVisitor.visitUse(usesName.replace('.', '/'));
+        }
         for (Map.Entry<String, List<String>> entry : providers.entrySet()) {
             String name = entry.getKey();
             List<String> implementations = entry.getValue();

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
@@ -32,6 +32,7 @@ public class ModuleInfo extends ModuleSpec {
     final Set<String> requiresTransitive = new LinkedHashSet<>();
     final Set<String> requiresStatic = new LinkedHashSet<>();
     final Set<String> ignoreServiceProviders = new LinkedHashSet<>();
+    final Set<String> uses = new LinkedHashSet<>();
 
     boolean exportAllPackages;
     boolean requireAllDefinedDependencies;
@@ -67,6 +68,13 @@ public class ModuleInfo extends ModuleSpec {
      */
     public void requiresStatic(String requiresStatic) {
         addOrThrow(this.requiresStatic, requiresStatic);
+    }
+
+    /**
+     * @param uses corresponds to the directive in a 'module-info.java' file
+     */
+    public void uses(String uses) {
+        addOrThrow(this.uses, uses);
     }
 
     /**


### PR DESCRIPTION
Based on a real world example that uses the jcache api. In this case the application would not start because the generated module-info.java was missing a `uses` clause, which could not be added to the generated module-info using the plugin.
This change adds support for uses directives and adds a unit test to verify that the resulting module-info is correct.