### PR TITLE
Enhancements: failOnAutomaticModules, Real Module Patching, and Module Specs Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,31 @@ extraJavaModuleInfo {
 }
 ```
 
+## How can I ensure there are no automatic modules in my dependency tree?
+
+If your goal is to fully modularize your application, you should enable the following configuration setting, which is disabled by default.
+
+```
+extraJavaModuleInfo {
+    failOnAutomaticModules.set(true)
+}
+```
+
+With this setting enabled, the build will fail unless you define a module override for every automatic module that appears in your dependency tree, as shown below.
+
+```
+dependencies {
+    implementation("org.yaml:snakeyaml:1.33")
+}             
+extraJavaModuleInfo {
+    failOnAutomaticModules.set(true)
+    module("org.yaml:snakeyaml", "org.yaml.snakeyaml") {
+        closeModule()
+        exports("org.yaml.snakeyaml")
+    }
+}
+```
+
 ## What do I do in a 'split package' situation?
 
 The Java Module System does not allow the same package to be used in more than one _module_.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ extraJavaModuleInfo {
 ```
 
 This opt-in behavior is designed to prevent over-patching real modules, especially during version upgrades. For example, when a newer version of a library already contains the proper `module-info.class`, the extra module info overrides should be removed.
+
 # Disclaimer
 
 Gradle and the Gradle logo are trademarks of Gradle, Inc.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ extraJavaModuleInfo {
 }
 ```
 
+## I have many automatic modules in my project. How can I convert them into proper modules and control what they export or require?
+
+The plugin provides a set of `<sourceSet>moduleDescriptorRecommendations` tasks that generate the real module declarations utilizing [jdeps](https://docs.oracle.com/en/java/javase/11/tools/jdeps.html) and dependency metadata.
+
+This task generates module info spec for the JARs that do not contain the proper `module-info.class` descriptors.
+
+NOTE: This functionality requires Gradle to be run with Java 11+ and failing on missing module information should be disabled via `failOnMissingModuleInfo.set(false)`.
+
 ## How can I ensure there are no automatic modules in my dependency tree?
 
 If your goal is to fully modularize your application, you should enable the following configuration setting, which is disabled by default.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This task generates module info spec for the JARs that do not contain the proper
 
 NOTE: This functionality requires Gradle to be run with Java 11+ and failing on missing module information should be disabled via `failOnMissingModuleInfo.set(false)`.
 
-## How can I ensure there are no automatic modules in my dependency tree?
+## How can I ensure there are no automatic modules in my dependency graph?
 
 If your goal is to fully modularize your application, you should enable the following configuration setting, which is disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,22 @@ This plugin offers the option to merge multiple Jars into one in such situations
 
 Note: The merged Jar will include the *first* appearance of duplicated files (like the `MANIFEST.MF`).
 
+## How can I fix a library with a broken `module-info.class`?
+
+To fix a library with a broken `module-info.class`, you can override the modular descriptor in the same way it is done with non-modular JARs. However, you need to specify `patchRealModule()` in order to avoid unintentional overrides.
+
+```
+extraJavaModuleInfo {                
+    module("org.apache.tomcat.embed:tomcat-embed-core", "org.apache.tomcat.embed.core") {
+        patchRealModule()
+        requires("java.desktop")
+        requires("java.instrument")
+        ...
+    }
+}    
+```
+
+This opt-in behavior is designed to prevent over-patching real modules, especially during version upgrades. For example, when a newer version of a library already contains the proper `module-info.class`, the extra module info overrides should be removed.
 # Disclaimer
 
 Gradle and the Gradle logo are trademarks of Gradle, Inc.

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPlugin.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPlugin.java
@@ -63,6 +63,7 @@ public abstract class ExtraJavaModuleInfoPlugin implements Plugin<Project> {
         // register the plugin extension as 'extraJavaModuleInfo {}' configuration block
         ExtraJavaModuleInfoPluginExtension extension = project.getExtensions().create("extraJavaModuleInfo", ExtraJavaModuleInfoPluginExtension.class);
         extension.getFailOnMissingModuleInfo().convention(true);
+        extension.getFailOnAutomaticModules().convention(false);
 
         // setup the transform for all projects in the build
         project.getPlugins().withType(JavaPlugin.class).configureEach(javaPlugin -> configureTransform(project, extension));
@@ -121,6 +122,7 @@ public abstract class ExtraJavaModuleInfoPlugin implements Plugin<Project> {
             t.parameters(p -> {
                 p.getModuleSpecs().set(extension.getModuleSpecs());
                 p.getFailOnMissingModuleInfo().set(extension.getFailOnMissingModuleInfo());
+                p.getFailOnAutomaticModules().set(extension.getFailOnAutomaticModules());
 
                 // See: https://github.com/adammurdoch/dependency-graph-as-task-inputs/blob/main/plugins/src/main/java/TestPlugin.java
                 Provider<Set<ResolvedArtifactResult>> artifacts = project.provider(() ->

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPluginExtension.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPluginExtension.java
@@ -39,6 +39,7 @@ public abstract class ExtraJavaModuleInfoPluginExtension {
 
     public abstract MapProperty<String, ModuleSpec> getModuleSpecs();
     public abstract Property<Boolean> getFailOnMissingModuleInfo();
+    public abstract Property<Boolean> getFailOnAutomaticModules();
 
     /**
      * Add full module information for a given Jar file.

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
@@ -121,7 +121,7 @@ public abstract class ExtraJavaModuleInfoTransform implements TransformAction<Ex
                 throw new RuntimeException("Patching of real modules must be explicitly enabled with patchRealModule() and can only be done with `module` spec");
             }
             if (parameters.getFailOnAutomaticModules().get()) {
-                throw new RuntimeException("Automatic modules are prohibited. Use `module` spec instead: " + originalJar.getName());
+                throw new RuntimeException("Use of 'automaticModule()' is prohibited. Use 'module()' instead: " + originalJar.getName());
             }
             addAutomaticModuleName(originalJar, getModuleJar(outputs, originalJar), (AutomaticModuleName) moduleSpec);
         } else if (realModule) {

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
@@ -113,12 +113,12 @@ public abstract class ExtraJavaModuleInfoTransform implements TransformAction<Ex
         boolean realModule = isModule(originalJar);
         if (moduleSpec instanceof ModuleInfo) {
             if (realModule && !((ModuleInfo) moduleSpec).patchRealModule) {
-                throw new RuntimeException("Patching of real modules must be explicitly enabled with patchRealModule()");
+                throw new RuntimeException("Patching of real modules must be explicitly enabled with 'patchRealModule()'");
             }
             addModuleDescriptor(originalJar, getModuleJar(outputs, originalJar), (ModuleInfo) moduleSpec);
         } else if (moduleSpec instanceof AutomaticModuleName) {
             if (realModule) {
-                throw new RuntimeException("Patching of real modules must be explicitly enabled with patchRealModule() and can only be done with `module` spec");
+                throw new RuntimeException("Patching of real modules must be explicitly enabled with 'patchRealModule()' and can only be done with 'module()'");
             }
             if (parameters.getFailOnAutomaticModules().get()) {
                 throw new RuntimeException("Use of 'automaticModule()' is prohibited. Use 'module()' instead: " + originalJar.getName());

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleDescriptorRecommendation.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleDescriptorRecommendation.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlex.javamodule.moduleinfo;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.spi.ToolProvider;
+
+public abstract class ModuleDescriptorRecommendation extends DefaultTask {
+
+    private static final class Artifact {
+
+        final ModuleIdentifier coordinates;
+
+        final Set<ModuleIdentifier> runtimeDependencies = new HashSet<>();
+
+        final Set<ModuleIdentifier> compileDependencies = new HashSet<>();
+
+        final File jar;
+
+        final SortedSet<String> requires = new TreeSet<>();
+        final SortedSet<String> requiresTransitive = new TreeSet<>();
+        final SortedSet<String> requiresStatic = new TreeSet<>();
+        final SortedSet<String> exports = new TreeSet<>();
+
+        final SortedSet<String> provides = new TreeSet<>();
+
+        String moduleName;
+
+        boolean automatic;
+
+        Artifact(ModuleIdentifier coordinates, File jar) {
+            this.coordinates = coordinates;
+            this.jar = jar;
+        }
+
+        Set<ModuleIdentifier> allDependencies() {
+            Set<ModuleIdentifier> out = new HashSet<>();
+            out.addAll(compileDependencies);
+            out.addAll(runtimeDependencies);
+            return out;
+        }
+
+        boolean containsAnyRequires(String moduleName) {
+            return requires.contains(moduleName) || requiresTransitive.contains(moduleName) || requiresStatic.contains(moduleName);
+        }
+
+        String dsl() {
+            List<String> out = new ArrayList<>();
+            String group = this.coordinates.getGroup();
+            String name = this.coordinates.getName();
+            String moduleName = this.moduleName;
+            out.add("module('" + group + ":" + name + "', '" + moduleName + "') {");
+            out.add("    closeModule()");
+            for (String item : this.requiresTransitive) {
+                out.add("    requiresTransitive('" + item + "')");
+            }
+            for (String item : this.requiresStatic) {
+                out.add("    requiresStatic('" + item + "')");
+            }
+            for (String item : this.requires) {
+                out.add("    requires('" + item + "')");
+            }
+            for (String item : this.exports) {
+                out.add("    exports('" + item + "')");
+            }
+            for (String item : this.provides) {
+                out.add("    // ignoreServiceProvider('" + item + "')");
+            }
+            out.add("}");
+            return String.join("\n", out)
+                    .replace('\'', '"');
+        }
+
+    }
+
+    interface Java8SafeToolProvider {
+
+        int run(PrintWriter out, PrintWriter err, String... args);
+
+        @SuppressWarnings("Since15")
+        static Java8SafeToolProvider findFirst(String name) {
+            try {
+                ToolProvider tool = ToolProvider.findFirst(name)
+                        .orElseThrow(() -> new RuntimeException("The JDK does not bundle " + name));
+                return tool::run;
+            } catch (NoClassDefFoundError e) {
+                throw new RuntimeException("This functionality requires Gradle to be powered by JDK 11+", e);
+            }
+        }
+
+    }
+
+    @Input
+    public abstract Property<Configuration> getRuntimeConfiguration();
+
+    @Input
+    public abstract Property<Configuration> getCompileConfiguration();
+
+    @Input
+    public abstract Property<Integer> getRelease();
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    @TaskAction
+    public void execute() throws IOException {
+        Java8SafeToolProvider jdepsTool = Java8SafeToolProvider.findFirst("jdeps");
+        Java8SafeToolProvider jarTool = Java8SafeToolProvider.findFirst("jar");
+
+        Map<ModuleIdentifier, Artifact> artifacts = new HashMap<>();
+        extractArtifactsAndTheirDependencies(artifacts, getRuntimeConfiguration().get(), artifact -> artifact.runtimeDependencies);
+        extractArtifactsAndTheirDependencies(artifacts, getCompileConfiguration().get(), artifact -> artifact.compileDependencies);
+
+        Path temporaryFolder = Files.createTempDirectory("jdeps-task");
+        for (Map.Entry<ModuleIdentifier, Artifact> entry : artifacts.entrySet()) {
+            Artifact artifact = entry.getValue();
+            storeJarToolParsedMetadata(jarTool, artifact);
+            if (artifact.automatic) {
+                storeJdepsToolParsedMetadata(jdepsTool, temporaryFolder, artifact, artifacts.values());
+            }
+        }
+        List<Artifact> modulesToRecommend = new ArrayList<>();
+        for (Map.Entry<ModuleIdentifier, Artifact> entry : artifacts.entrySet()) {
+            Artifact artifact = entry.getValue();
+            if (artifact.automatic) {
+                for (ModuleIdentifier dependency : artifact.allDependencies()) {
+                    Artifact dependencyArtifact = artifacts.get(dependency);
+                    // If the dependency modifier was not identified by jdeps, try to find it the "best" possible requires modifier
+                    // using the same heuristic that is utilized by "requireAllDefinedDependencies()".
+                    if (!artifact.containsAnyRequires(dependencyArtifact.moduleName)) {
+                        boolean hasCompileDependency = artifact.compileDependencies.contains(dependencyArtifact.coordinates);
+                        boolean hasRuntimeDependency = artifact.runtimeDependencies.contains(dependencyArtifact.coordinates);
+                        if (hasCompileDependency && hasRuntimeDependency) {
+                            artifact.requiresTransitive.add(dependencyArtifact.moduleName);
+                        } else if (hasRuntimeDependency) {
+                            artifact.requires.add(dependencyArtifact.moduleName);
+                        } else if (hasCompileDependency) {
+                            artifact.requiresStatic.add(dependencyArtifact.moduleName);
+                        }
+                    }
+                }
+                modulesToRecommend.add(artifact);
+            }
+        }
+
+        modulesToRecommend.sort(Comparator.<Artifact, String>comparing(entry -> entry.coordinates.getGroup()).thenComparing(entry->entry.coordinates.getName()));
+
+        for (Artifact artifact : modulesToRecommend) {
+            System.out.println(artifact.dsl());
+        }
+
+        if (modulesToRecommend.isEmpty()) {
+            System.out.println("All good. Looks like all the dependencies have the proper module-info.class defined");
+        }
+
+        getFileSystemOperations().delete(spec -> spec.delete(temporaryFolder));
+    }
+
+    private static void extractArtifactsAndTheirDependencies(Map<ModuleIdentifier, Artifact> jarsToAnalyze, Configuration configuration, Function<Artifact, Set<ModuleIdentifier>> depsSink) {
+        for (ResolvedArtifactResult artifact : configuration.getIncoming().getArtifacts()) {
+            ComponentIdentifier identifier = artifact.getId().getComponentIdentifier();
+            if (identifier instanceof ModuleComponentIdentifier) {
+                ModuleIdentifier moduleIdentifier = ((ModuleComponentIdentifier) identifier).getModuleIdentifier();
+                jarsToAnalyze.computeIfAbsent(moduleIdentifier, (ignore) -> new Artifact(moduleIdentifier, artifact.getFile()));
+            }
+        }
+        for (ResolvedComponentResult resolvedComponent : configuration.getIncoming().getResolutionResult().getAllComponents()) {
+            ModuleVersionIdentifier moduleVersion = resolvedComponent.getModuleVersion();
+            if (moduleVersion == null) {
+                continue;
+            }
+            Artifact artifact = jarsToAnalyze.get(moduleVersion.getModule());
+            if (artifact == null) {
+                continue;
+            }
+            for (DependencyResult dependency : resolvedComponent.getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult) {
+                    ModuleVersionIdentifier dependantModuleVersion = ((ResolvedDependencyResult) dependency).getSelected().getModuleVersion();
+                    if (dependantModuleVersion != null) {
+                        depsSink.apply(artifact).add(dependantModuleVersion.getModule());
+                    }
+                }
+            }
+        }
+    }
+
+    private static final Pattern REQUIRES_PATTERN = Pattern.compile("^ {4}requires (transitive )?(.*);$");
+    private static final Pattern EXPORTS_PATTERN = Pattern.compile("^ {4}exports (.*);$");
+    private static final Pattern PROVIDES_PATTERN = Pattern.compile("^ {4}provides (.*) with$");
+
+    @SuppressWarnings("Since15")
+    private void storeJdepsToolParsedMetadata(Java8SafeToolProvider jdeps, Path outputPath, Artifact targetArtifact, Collection<Artifact> jars) throws IOException {
+        List<String> modulePath = new ArrayList<>();
+        for (Artifact artifact : jars) {
+            if (!artifact.equals(targetArtifact)) {
+                modulePath.add(artifact.jar.getAbsolutePath());
+            }
+        }
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        List<String> args = new ArrayList<>();
+        if (!modulePath.isEmpty()) {
+            args.addAll(List.of( "--module-path", String.join(File.pathSeparator, modulePath)));
+        }
+        args.addAll(List.of("--generate-module-info", outputPath.toString()));
+        args.addAll(List.of("--multi-release", String.valueOf(getRelease().get())));
+        args.add("--ignore-missing-deps");
+        args.add(targetArtifact.jar.getAbsolutePath());
+        int retVal = jdeps.run(new PrintWriter(out, true), new PrintWriter(err, true), args.toArray(String[]::new));
+        if (retVal != 0) {
+            throw new RuntimeException(String.format("jdeps returned error %d\n%s\n%s", retVal, out, err));
+        }
+        String[] result = out.toString().split("\\R");
+        String writingToMessage = result.length == 2
+                ? result[1] // Skipping "Warning: --ignore-missing-deps specified. Missing dependencies from xyz are ignored"
+                : result[0];
+        String path = writingToMessage.replace("writing to ", "");
+        String moduleInfoJava = Files.readString(Path.of(path));
+        String[] parts = moduleInfoJava.split("\\R");
+        for (String part : parts) {
+            Matcher requiresMatcher = REQUIRES_PATTERN.matcher(part);
+            if (requiresMatcher.matches()) {
+                if (requiresMatcher.group(1) == null) {
+                    targetArtifact.requires.add(requiresMatcher.group(2));
+                } else {
+                    targetArtifact.requiresTransitive.add(requiresMatcher.group(2));
+                }
+                continue;
+            }
+            Matcher exportsMatcher = EXPORTS_PATTERN.matcher(part);
+            if (exportsMatcher.matches()) {
+                targetArtifact.exports.add(exportsMatcher.group(1));
+                continue;
+            }
+            Matcher providesMatcher = PROVIDES_PATTERN.matcher(part);
+            if (providesMatcher.matches()) {
+                targetArtifact.provides.add(providesMatcher.group(1));
+            }
+        }
+    }
+
+    private static final Pattern AUTOMATIC_MODULE_NAME_PATTERN = Pattern.compile("(.*?)(@.*)? automatic");
+    private static final Pattern MODULE_INFO_CLASS_MODULE_NAME_PATTERN = Pattern.compile("(.*?)(@.*)? jar:(.*)");
+
+    private void storeJarToolParsedMetadata(Java8SafeToolProvider jar, Artifact artifact) {
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        int retVal = jar.run(
+                new PrintWriter(out, true),
+                new PrintWriter(err, true),
+                "--describe-module",
+                "--file",
+                artifact.jar.getAbsolutePath(),
+                "--release",
+                String.valueOf(getRelease().get())
+        );
+        if (retVal != 0) {
+            throw new RuntimeException(String.format("jar returned error %d\n%s\n%s", retVal, out, err));
+        }
+        String[] result = out.toString().split("\\R");
+        if (result[0].equals("No module descriptor found. Derived automatic module.")) {
+            Matcher matcher = AUTOMATIC_MODULE_NAME_PATTERN.matcher(result[2]);
+            if (!matcher.matches()) {
+                throw new RuntimeException("Cannot extract module name from: " + out);
+            }
+            artifact.moduleName = matcher.group(1);
+            artifact.automatic = true;
+        } else {
+            Matcher matcher = MODULE_INFO_CLASS_MODULE_NAME_PATTERN.matcher(result[0].startsWith("releases: ") ? result[2] : result[0]);
+            if (!matcher.matches()) {
+                throw new RuntimeException("Cannot extract module name from: " + out);
+            }
+            artifact.moduleName = matcher.group(1);
+            artifact.automatic = false;
+        }
+    }
+
+}

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
@@ -40,6 +40,7 @@ public class ModuleInfo extends ModuleSpec {
 
     boolean exportAllPackages;
     boolean requireAllDefinedDependencies;
+    boolean patchRealModule;
 
     ModuleInfo(String identifier, String moduleName, String moduleVersion, ObjectFactory objectFactory) {
         super(identifier, moduleName);
@@ -131,4 +132,12 @@ public class ModuleInfo extends ModuleSpec {
     public void requireAllDefinedDependencies() {
         this.requireAllDefinedDependencies = true;
     }
+
+    /**
+     * Explicitly allow patching real (JARs with module-info.class) modules
+     */
+    public void patchRealModule() {
+        this.patchRealModule = true;
+    }
+
 }

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/AllowAutomaticModulesFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/AllowAutomaticModulesFunctionalTest.groovy
@@ -1,0 +1,93 @@
+package org.gradlex.javamodule.moduleinfo.test
+
+import org.gradlex.javamodule.moduleinfo.test.fixture.GradleBuild
+import spock.lang.Specification
+
+class AllowAutomaticModulesFunctionalTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    def setup() {
+        settingsFile << 'rootProject.name = "test-project"'
+        buildFile << '''
+            plugins {                
+                id("application")
+                id("org.gradlex.extra-java-module-info")
+            }
+            application {
+                mainModule.set("org.gradle.sample.app")
+                mainClass.set("org.gradle.sample.app.Main")
+            }
+        '''
+        file("src/main/java/module-info.java") << '''
+            module org.gradle.sample.app {
+                requires org.yaml.snakeyaml;
+            }
+        '''
+        file("src/main/java/org/gradle/sample/app/Main.java") << '''
+            package org.gradle.sample.app;
+
+            import org.yaml.snakeyaml.Yaml;
+            
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("Automatic: " + Yaml.class.getModule().getDescriptor().isAutomatic());
+                }
+            }
+        '''
+    }
+
+    def "automatic modules are allowed by default"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.yaml:snakeyaml:1.33")
+            }             
+            extraJavaModuleInfo {
+                
+            }
+        '''
+
+        expect:
+        def out = run()
+        out.output.contains("Automatic: true")
+    }
+
+    def "automatic modules are not allowed when failOnAutomaticModules set to true"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.yaml:snakeyaml:1.33")
+            }             
+            extraJavaModuleInfo {
+                failOnAutomaticModules.set(true)
+            }
+        '''
+
+        expect:
+        def out = failRun()
+        out.output.contains("Found an automatic module: snakeyaml-1.33.jar")
+    }
+
+    def "automatic modules are allowed when failOnAutomaticModules set to true and there is a proper module override"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.yaml:snakeyaml:1.33")
+            }             
+            extraJavaModuleInfo {
+                failOnAutomaticModules.set(true)
+                module("org.yaml:snakeyaml", "org.yaml.snakeyaml") {
+                    closeModule()
+                    exports("org.yaml.snakeyaml")
+                }
+            }
+        '''
+
+        expect:
+        def out = run()
+        out.output.contains("Automatic: false")
+    }
+
+}

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RealModuleJarPatchingFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RealModuleJarPatchingFunctionalTest.groovy
@@ -1,0 +1,202 @@
+package org.gradlex.javamodule.moduleinfo.test
+
+import org.gradlex.javamodule.moduleinfo.test.fixture.GradleBuild
+import spock.lang.Specification
+
+class RealModuleJarPatchingFunctionalTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    def setup() {
+        settingsFile << 'rootProject.name = "test-project"'
+        buildFile << '''
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+                       
+            tasks.register<JavaExec>("run") {
+                mainClass.set("jdk.tools.jlink.internal.Main")
+                mainModule.set("jdk.jlink")
+                args = listOf(
+                        "--module-path",
+                        configurations.runtimeClasspath.get().asPath,
+                        "--output",
+                        "jlink-image-test",
+                        "--add-modules",
+                        "org.apache.tomcat.embed.core"
+                )
+            }
+                                                
+        '''
+    }
+
+    def "jlink fails because of a broken module descriptor"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.13")
+            }
+            
+            extraJavaModuleInfo {
+            
+            }                       
+        '''
+
+        expect:
+        def out = failRun()
+        out.output.contains("Packages that are exported or open in org.apache.tomcat.embed.core are not present: [org.apache.catalina.ssi]")
+    }
+
+    def "jlink succeeds with the patched module descriptor"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.13")
+            }
+            
+            extraJavaModuleInfo {                
+                module("org.apache.tomcat.embed:tomcat-embed-core", "org.apache.tomcat.embed.core") {
+                    patchRealModule()
+                    requires("java.desktop")
+                    requires("java.instrument")
+                    requires("java.logging")
+                    requires("java.rmi")
+            
+                    requiresStatic("jakarta.ejb")
+                    requiresStatic("jakarta.mail")
+                    requiresStatic("jakarta.persistence")
+                    requiresStatic("jakarta.xml.ws")
+                    requiresStatic("java.xml.ws")
+            
+                    requiresTransitive("jakarta.annotation")
+                    requiresTransitive("java.management")
+                    requiresTransitive("java.naming")
+                    requiresTransitive("java.security.jgss")
+                    requiresTransitive("java.sql")
+                    requiresTransitive("java.xml")
+            
+                    exports("jakarta.security.auth.message")
+                    exports("jakarta.security.auth.message.callback")
+                    exports("jakarta.security.auth.message.config")
+                    exports("jakarta.security.auth.message.module")
+                    exports("jakarta.servlet")
+                    exports("jakarta.servlet.annotation")
+                    exports("jakarta.servlet.descriptor")
+                    exports("jakarta.servlet.http")
+                    exports("jakarta.servlet.resources")
+                    exports("org.apache.catalina")
+                    exports("org.apache.catalina.authenticator")
+                    exports("org.apache.catalina.authenticator.jaspic")
+                    exports("org.apache.catalina.connector")
+                    exports("org.apache.catalina.core")
+                    exports("org.apache.catalina.deploy")
+                    exports("org.apache.catalina.filters")
+                    exports("org.apache.catalina.loader")
+                    exports("org.apache.catalina.manager")
+                    exports("org.apache.catalina.manager.host")
+                    exports("org.apache.catalina.manager.util")
+                    exports("org.apache.catalina.mapper")
+                    exports("org.apache.catalina.mbeans")
+                    exports("org.apache.catalina.realm")
+                    exports("org.apache.catalina.security")
+                    exports("org.apache.catalina.servlets")
+                    exports("org.apache.catalina.session")
+                    // The only difference with the bundled module-info.class
+                    // exports("org.apache.catalina.ssi")
+                    exports("org.apache.catalina.startup")
+                    exports("org.apache.catalina.users")
+                    exports("org.apache.catalina.util")
+                    exports("org.apache.catalina.valves")
+                    exports("org.apache.catalina.valves.rewrite")
+                    exports("org.apache.catalina.webresources")
+                    exports("org.apache.catalina.webresources.war")
+                    exports("org.apache.coyote")
+                    exports("org.apache.coyote.ajp")
+                    exports("org.apache.coyote.http11")
+                    exports("org.apache.coyote.http11.filters")
+                    exports("org.apache.coyote.http11.upgrade")
+                    exports("org.apache.coyote.http2")
+                    exports("org.apache.juli")
+                    exports("org.apache.juli.logging")
+                    exports("org.apache.naming")
+                    exports("org.apache.naming.factory")
+                    exports("org.apache.naming.java")
+                    exports("org.apache.tomcat")
+                    exports("org.apache.tomcat.jni")
+                    exports("org.apache.tomcat.util")
+                    exports("org.apache.tomcat.util.bcel.classfile")
+                    exports("org.apache.tomcat.util.buf")
+                    exports("org.apache.tomcat.util.codec.binary")
+                    exports("org.apache.tomcat.util.collections")
+                    exports("org.apache.tomcat.util.compat")
+                    exports("org.apache.tomcat.util.descriptor")
+                    exports("org.apache.tomcat.util.descriptor.tagplugin")
+                    exports("org.apache.tomcat.util.descriptor.web")
+                    exports("org.apache.tomcat.util.digester")
+                    exports("org.apache.tomcat.util.file")
+                    exports("org.apache.tomcat.util.http")
+                    exports("org.apache.tomcat.util.http.fileupload")
+                    exports("org.apache.tomcat.util.http.fileupload.disk")
+                    exports("org.apache.tomcat.util.http.fileupload.impl")
+                    exports("org.apache.tomcat.util.http.fileupload.servlet")
+                    exports("org.apache.tomcat.util.http.fileupload.util")
+                    exports("org.apache.tomcat.util.http.parser")
+                    exports("org.apache.tomcat.util.log")
+                    exports("org.apache.tomcat.util.modeler")
+                    exports("org.apache.tomcat.util.modeler.modules")
+                    exports("org.apache.tomcat.util.net")
+                    exports("org.apache.tomcat.util.net.openssl")
+                    exports("org.apache.tomcat.util.net.openssl.ciphers")
+                    exports("org.apache.tomcat.util.res")
+                    exports("org.apache.tomcat.util.scan")
+                    exports("org.apache.tomcat.util.security")
+                    exports("org.apache.tomcat.util.threads")
+            
+                    uses("org.apache.juli.logging.Log")                    
+                }
+            }               
+        '''
+
+        expect:
+        run()
+    }
+
+    def "patching of real modules must be explicitly enabled"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.13")
+            }
+                        
+            extraJavaModuleInfo {                
+                module("org.apache.tomcat.embed:tomcat-embed-core", "org.apache.tomcat.embed.core") {                    
+                    requires("java.desktop")
+                }
+            }                       
+        '''
+
+        expect:
+        def out = failRun()
+        out.output.contains("Patching of real modules must be explicitly enabled with patchRealModule()")
+    }
+
+    def "a real module cannot be demoted to an automatic module"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.13")
+            }
+                        
+            extraJavaModuleInfo {                
+                automaticModule("org.apache.tomcat.embed:tomcat-embed-core", "org.apache.tomcat.embed.core")
+            }                       
+        '''
+
+        expect:
+        def out = failRun()
+        out.output.contains("Patching of real modules must be explicitly enabled with patchRealModule() and can only be done with `module` spec")
+    }
+
+}

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RealModuleJarPatchingFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RealModuleJarPatchingFunctionalTest.groovy
@@ -179,7 +179,7 @@ class RealModuleJarPatchingFunctionalTest extends Specification {
 
         expect:
         def out = failRun()
-        out.output.contains("Patching of real modules must be explicitly enabled with patchRealModule()")
+        out.output.contains("Patching of real modules must be explicitly enabled with 'patchRealModule()'")
     }
 
     def "a real module cannot be demoted to an automatic module"() {
@@ -196,7 +196,7 @@ class RealModuleJarPatchingFunctionalTest extends Specification {
 
         expect:
         def out = failRun()
-        out.output.contains("Patching of real modules must be explicitly enabled with patchRealModule() and can only be done with `module` spec")
+        out.output.contains("Patching of real modules must be explicitly enabled with 'patchRealModule()' and can only be done with 'module()'")
     }
 
 }

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RecommendModuleSpecFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RecommendModuleSpecFunctionalTest.groovy
@@ -1,0 +1,519 @@
+package org.gradlex.javamodule.moduleinfo.test
+
+import org.gradlex.javamodule.moduleinfo.test.fixture.GradleBuild
+import spock.lang.Specification
+
+class RecommendModuleSpecFunctionalTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    def setup() {
+        settingsFile << 'rootProject.name = "test-project"'
+    }
+
+    def "generates a recommendation for an automatic module defined via Manifest"() {
+        given:
+        buildFile << ''' 
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+            dependencies {
+                implementation("org.yaml:snakeyaml:1.33")
+            }            
+        '''
+
+        expect:
+        def out = task("moduleDescriptorRecommendations")
+        out.output.contains('''
+            |module("org.yaml:snakeyaml", "org.yaml.snakeyaml") {
+            |    closeModule()
+            |    requiresTransitive("java.desktop")
+            |    requires("java.logging")
+            |    exports("org.yaml.snakeyaml")
+            |    exports("org.yaml.snakeyaml.comments")
+            |    exports("org.yaml.snakeyaml.composer")
+            |    exports("org.yaml.snakeyaml.constructor")
+            |    exports("org.yaml.snakeyaml.emitter")
+            |    exports("org.yaml.snakeyaml.env")
+            |    exports("org.yaml.snakeyaml.error")
+            |    exports("org.yaml.snakeyaml.events")
+            |    exports("org.yaml.snakeyaml.extensions.compactnotation")
+            |    exports("org.yaml.snakeyaml.external.biz.base64Coder")
+            |    exports("org.yaml.snakeyaml.external.com.google.gdata.util.common.base")
+            |    exports("org.yaml.snakeyaml.introspector")
+            |    exports("org.yaml.snakeyaml.nodes")
+            |    exports("org.yaml.snakeyaml.parser")
+            |    exports("org.yaml.snakeyaml.reader")
+            |    exports("org.yaml.snakeyaml.representer")
+            |    exports("org.yaml.snakeyaml.resolver")
+            |    exports("org.yaml.snakeyaml.scanner")
+            |    exports("org.yaml.snakeyaml.serializer")
+            |    exports("org.yaml.snakeyaml.tokens")
+            |    exports("org.yaml.snakeyaml.util")
+            |}'''.stripMargin())
+    }
+
+    def "does not provide recommendations for already modular jars"() {
+        given:
+        buildFile << ''' 
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+            
+            extraJavaModuleInfo {
+                failOnMissingModuleInfo.set(false)
+            }
+            
+            dependencies {                
+                implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+            }            
+        '''
+
+        expect:
+        def out = task("moduleDescriptorRecommendations")
+        out.output.contains('All good. Looks like all the dependencies have the proper module-info.class defined')
+        !out.output.contains('module(')
+    }
+
+    def "supports different source sets"() {
+        given:
+        buildFile << ''' 
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+            
+            extraJavaModuleInfo {
+                failOnMissingModuleInfo.set(false)
+            }
+            
+            dependencies {                
+                implementation("jakarta.servlet:jakarta.servlet-api:4.0.2")
+                testImplementation("junit:junit:4.13.2")
+            }            
+        '''
+
+        expect:
+        def out = task("testModuleDescriptorRecommendations")
+        out.output.contains('''
+        |module("jakarta.servlet:jakarta.servlet-api", "jakarta.servlet.api") {
+        |    closeModule()
+        |    exports("javax.servlet")
+        |    exports("javax.servlet.annotation")
+        |    exports("javax.servlet.descriptor")
+        |    exports("javax.servlet.http")
+        |}
+        |module("junit:junit", "junit") {
+        |    closeModule()
+        |    requiresTransitive("hamcrest.core")
+        |    exports("junit.extensions")
+        |    exports("junit.framework")
+        |    exports("junit.runner")
+        |    exports("junit.textui")
+        |    exports("org.junit")
+        |    exports("org.junit.experimental")
+        |    exports("org.junit.experimental.categories")
+        |    exports("org.junit.experimental.max")
+        |    exports("org.junit.experimental.results")
+        |    exports("org.junit.experimental.runners")
+        |    exports("org.junit.experimental.theories")
+        |    exports("org.junit.experimental.theories.internal")
+        |    exports("org.junit.experimental.theories.suppliers")
+        |    exports("org.junit.function")
+        |    exports("org.junit.internal")
+        |    exports("org.junit.internal.builders")
+        |    exports("org.junit.internal.management")
+        |    exports("org.junit.internal.matchers")
+        |    exports("org.junit.internal.requests")
+        |    exports("org.junit.internal.runners")
+        |    exports("org.junit.internal.runners.model")
+        |    exports("org.junit.internal.runners.rules")
+        |    exports("org.junit.internal.runners.statements")
+        |    exports("org.junit.matchers")
+        |    exports("org.junit.rules")
+        |    exports("org.junit.runner")
+        |    exports("org.junit.runner.manipulation")
+        |    exports("org.junit.runner.notification")
+        |    exports("org.junit.runners")
+        |    exports("org.junit.runners.model")
+        |    exports("org.junit.runners.parameterized")
+        |    exports("org.junit.validator")
+        |}
+        |module("org.hamcrest:hamcrest-core", "hamcrest.core") {
+        |    closeModule()
+        |    exports("org.hamcrest")
+        |    exports("org.hamcrest.core")
+        |    exports("org.hamcrest.internal")
+        |}'''.stripMargin())
+    }
+
+    def "generates a recommendation for a module that is missing `Automatic-Module-Name` in manifest"() {
+        given:
+        buildFile << ''' 
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+            
+            extraJavaModuleInfo {
+                failOnMissingModuleInfo.set(false)
+            }
+            
+            dependencies {
+                implementation("javax.inject:javax.inject:1")
+            }            
+        '''
+
+        expect:
+        def out = task("moduleDescriptorRecommendations")
+        out.output.contains('''
+            |module("javax.inject:javax.inject", "javax.inject") {
+            |    closeModule()
+            |    exports("javax.inject")
+            |}'''.stripMargin())
+    }
+
+    def "generates multiple recommendations based on a large classpath configuration"() {
+        given:
+        buildFile << ''' 
+            plugins {
+                id("java")
+                id("org.gradlex.extra-java-module-info")
+            }
+            
+            extraJavaModuleInfo {
+                failOnMissingModuleInfo.set(false)
+            }
+            
+            dependencies {
+                implementation("org.springframework:spring-webmvc:5.3.30")
+                implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+            }            
+        '''
+
+        expect:
+        def out = task("moduleDescriptorRecommendations")
+        out.output.contains('''
+            |module("org.springframework:spring-aop", "spring.aop") {
+            |    closeModule()
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("spring.beans")
+            |    requiresTransitive("spring.core")
+            |    requiresTransitive("spring.jcl")
+            |    exports("org.aopalliance.aop")
+            |    exports("org.aopalliance.intercept")
+            |    exports("org.springframework.aop")
+            |    exports("org.springframework.aop.aspectj")
+            |    exports("org.springframework.aop.aspectj.annotation")
+            |    exports("org.springframework.aop.aspectj.autoproxy")
+            |    exports("org.springframework.aop.config")
+            |    exports("org.springframework.aop.framework")
+            |    exports("org.springframework.aop.framework.adapter")
+            |    exports("org.springframework.aop.framework.autoproxy")
+            |    exports("org.springframework.aop.framework.autoproxy.target")
+            |    exports("org.springframework.aop.interceptor")
+            |    exports("org.springframework.aop.scope")
+            |    exports("org.springframework.aop.support")
+            |    exports("org.springframework.aop.support.annotation")
+            |    exports("org.springframework.aop.target")
+            |    exports("org.springframework.aop.target.dynamic")
+            |}
+            |module("org.springframework:spring-beans", "spring.beans") {
+            |    closeModule()
+            |    requiresTransitive("java.desktop")
+            |    requiresTransitive("java.prefs")
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("spring.core")
+            |    requiresTransitive("spring.jcl")
+            |    exports("org.springframework.beans")
+            |    exports("org.springframework.beans.annotation")
+            |    exports("org.springframework.beans.factory")
+            |    exports("org.springframework.beans.factory.annotation")
+            |    exports("org.springframework.beans.factory.config")
+            |    exports("org.springframework.beans.factory.groovy")
+            |    exports("org.springframework.beans.factory.parsing")
+            |    exports("org.springframework.beans.factory.serviceloader")
+            |    exports("org.springframework.beans.factory.support")
+            |    exports("org.springframework.beans.factory.wiring")
+            |    exports("org.springframework.beans.factory.xml")
+            |    exports("org.springframework.beans.propertyeditors")
+            |    exports("org.springframework.beans.support")
+            |}
+            |module("org.springframework:spring-context", "spring.context") {
+            |    closeModule()
+            |    requiresTransitive("java.desktop")
+            |    requiresTransitive("java.instrument")
+            |    requiresTransitive("java.management")
+            |    requiresTransitive("java.naming")
+            |    requiresTransitive("java.rmi")
+            |    requiresTransitive("java.scripting")
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("jdk.httpserver")
+            |    requiresTransitive("spring.aop")
+            |    requiresTransitive("spring.beans")
+            |    requiresTransitive("spring.core")
+            |    requiresTransitive("spring.expression")
+            |    requiresTransitive("spring.jcl")
+            |    exports("org.springframework.cache")
+            |    exports("org.springframework.cache.annotation")
+            |    exports("org.springframework.cache.concurrent")
+            |    exports("org.springframework.cache.config")
+            |    exports("org.springframework.cache.interceptor")
+            |    exports("org.springframework.cache.support")
+            |    exports("org.springframework.context")
+            |    exports("org.springframework.context.annotation")
+            |    exports("org.springframework.context.config")
+            |    exports("org.springframework.context.event")
+            |    exports("org.springframework.context.expression")
+            |    exports("org.springframework.context.i18n")
+            |    exports("org.springframework.context.index")
+            |    exports("org.springframework.context.support")
+            |    exports("org.springframework.context.weaving")
+            |    exports("org.springframework.ejb.access")
+            |    exports("org.springframework.ejb.config")
+            |    exports("org.springframework.format")
+            |    exports("org.springframework.format.annotation")
+            |    exports("org.springframework.format.datetime")
+            |    exports("org.springframework.format.datetime.joda")
+            |    exports("org.springframework.format.datetime.standard")
+            |    exports("org.springframework.format.number")
+            |    exports("org.springframework.format.number.money")
+            |    exports("org.springframework.format.support")
+            |    exports("org.springframework.instrument.classloading")
+            |    exports("org.springframework.instrument.classloading.glassfish")
+            |    exports("org.springframework.instrument.classloading.jboss")
+            |    exports("org.springframework.instrument.classloading.tomcat")
+            |    exports("org.springframework.instrument.classloading.weblogic")
+            |    exports("org.springframework.instrument.classloading.websphere")
+            |    exports("org.springframework.jmx")
+            |    exports("org.springframework.jmx.access")
+            |    exports("org.springframework.jmx.export")
+            |    exports("org.springframework.jmx.export.annotation")
+            |    exports("org.springframework.jmx.export.assembler")
+            |    exports("org.springframework.jmx.export.metadata")
+            |    exports("org.springframework.jmx.export.naming")
+            |    exports("org.springframework.jmx.export.notification")
+            |    exports("org.springframework.jmx.support")
+            |    exports("org.springframework.jndi")
+            |    exports("org.springframework.jndi.support")
+            |    exports("org.springframework.remoting")
+            |    exports("org.springframework.remoting.rmi")
+            |    exports("org.springframework.remoting.soap")
+            |    exports("org.springframework.remoting.support")
+            |    exports("org.springframework.scheduling")
+            |    exports("org.springframework.scheduling.annotation")
+            |    exports("org.springframework.scheduling.concurrent")
+            |    exports("org.springframework.scheduling.config")
+            |    exports("org.springframework.scheduling.support")
+            |    exports("org.springframework.scripting")
+            |    exports("org.springframework.scripting.bsh")
+            |    exports("org.springframework.scripting.config")
+            |    exports("org.springframework.scripting.groovy")
+            |    exports("org.springframework.scripting.support")
+            |    exports("org.springframework.stereotype")
+            |    exports("org.springframework.ui")
+            |    exports("org.springframework.ui.context")
+            |    exports("org.springframework.ui.context.support")
+            |    exports("org.springframework.validation")
+            |    exports("org.springframework.validation.annotation")
+            |    exports("org.springframework.validation.beanvalidation")
+            |    exports("org.springframework.validation.support")
+            |}
+            |module("org.springframework:spring-core", "spring.core") {
+            |    closeModule()
+            |    requiresTransitive("java.desktop")
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("jdk.unsupported")
+            |    requiresTransitive("spring.jcl")
+            |    requires("jdk.jfr")
+            |    exports("org.springframework.asm")
+            |    exports("org.springframework.cglib")
+            |    exports("org.springframework.cglib.beans")
+            |    exports("org.springframework.cglib.core")
+            |    exports("org.springframework.cglib.core.internal")
+            |    exports("org.springframework.cglib.proxy")
+            |    exports("org.springframework.cglib.reflect")
+            |    exports("org.springframework.cglib.transform")
+            |    exports("org.springframework.cglib.transform.impl")
+            |    exports("org.springframework.cglib.util")
+            |    exports("org.springframework.core")
+            |    exports("org.springframework.core.annotation")
+            |    exports("org.springframework.core.codec")
+            |    exports("org.springframework.core.convert")
+            |    exports("org.springframework.core.convert.converter")
+            |    exports("org.springframework.core.convert.support")
+            |    exports("org.springframework.core.env")
+            |    exports("org.springframework.core.io")
+            |    exports("org.springframework.core.io.buffer")
+            |    exports("org.springframework.core.io.support")
+            |    exports("org.springframework.core.log")
+            |    exports("org.springframework.core.metrics")
+            |    exports("org.springframework.core.metrics.jfr")
+            |    exports("org.springframework.core.serializer")
+            |    exports("org.springframework.core.serializer.support")
+            |    exports("org.springframework.core.style")
+            |    exports("org.springframework.core.task")
+            |    exports("org.springframework.core.task.support")
+            |    exports("org.springframework.core.type")
+            |    exports("org.springframework.core.type.classreading")
+            |    exports("org.springframework.core.type.filter")
+            |    exports("org.springframework.lang")
+            |    exports("org.springframework.objenesis")
+            |    exports("org.springframework.objenesis.instantiator")
+            |    exports("org.springframework.objenesis.instantiator.android")
+            |    exports("org.springframework.objenesis.instantiator.annotations")
+            |    exports("org.springframework.objenesis.instantiator.basic")
+            |    exports("org.springframework.objenesis.instantiator.gcj")
+            |    exports("org.springframework.objenesis.instantiator.perc")
+            |    exports("org.springframework.objenesis.instantiator.sun")
+            |    exports("org.springframework.objenesis.instantiator.util")
+            |    exports("org.springframework.objenesis.strategy")
+            |    exports("org.springframework.util")
+            |    exports("org.springframework.util.backoff")
+            |    exports("org.springframework.util.comparator")
+            |    exports("org.springframework.util.concurrent")
+            |    exports("org.springframework.util.function")
+            |    exports("org.springframework.util.unit")
+            |    exports("org.springframework.util.xml")
+            |    // ignoreServiceProvider("reactor.blockhound.integration.BlockHoundIntegration")
+            |}
+            |module("org.springframework:spring-expression", "spring.expression") {
+            |    closeModule()
+            |    requiresTransitive("spring.core")
+            |    requires("spring.jcl")
+            |    exports("org.springframework.expression")
+            |    exports("org.springframework.expression.common")
+            |    exports("org.springframework.expression.spel")
+            |    exports("org.springframework.expression.spel.ast")
+            |    exports("org.springframework.expression.spel.standard")
+            |    exports("org.springframework.expression.spel.support")
+            |}
+            |module("org.springframework:spring-jcl", "spring.jcl") {
+            |    closeModule()
+            |    requires("java.logging")
+            |    exports("org.apache.commons.logging")
+            |    exports("org.apache.commons.logging.impl")
+            |    // ignoreServiceProvider("org.apache.commons.logging.LogFactory")
+            |}
+            |module("org.springframework:spring-web", "spring.web") {
+            |    closeModule()
+            |    requiresTransitive("com.fasterxml.jackson.annotation")
+            |    requiresTransitive("com.fasterxml.jackson.core")
+            |    requiresTransitive("com.fasterxml.jackson.databind")
+            |    requiresTransitive("java.desktop")
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("jdk.httpserver")
+            |    requiresTransitive("spring.aop")
+            |    requiresTransitive("spring.beans")
+            |    requiresTransitive("spring.context")
+            |    requiresTransitive("spring.core")
+            |    requiresTransitive("spring.jcl")
+            |    requires("java.rmi")
+            |    exports("org.springframework.http")
+            |    exports("org.springframework.http.client")
+            |    exports("org.springframework.http.client.reactive")
+            |    exports("org.springframework.http.client.support")
+            |    exports("org.springframework.http.codec")
+            |    exports("org.springframework.http.codec.cbor")
+            |    exports("org.springframework.http.codec.json")
+            |    exports("org.springframework.http.codec.multipart")
+            |    exports("org.springframework.http.codec.protobuf")
+            |    exports("org.springframework.http.codec.support")
+            |    exports("org.springframework.http.codec.xml")
+            |    exports("org.springframework.http.converter")
+            |    exports("org.springframework.http.converter.cbor")
+            |    exports("org.springframework.http.converter.feed")
+            |    exports("org.springframework.http.converter.json")
+            |    exports("org.springframework.http.converter.protobuf")
+            |    exports("org.springframework.http.converter.smile")
+            |    exports("org.springframework.http.converter.support")
+            |    exports("org.springframework.http.converter.xml")
+            |    exports("org.springframework.http.server")
+            |    exports("org.springframework.http.server.reactive")
+            |    exports("org.springframework.remoting.caucho")
+            |    exports("org.springframework.remoting.httpinvoker")
+            |    exports("org.springframework.remoting.jaxws")
+            |    exports("org.springframework.web")
+            |    exports("org.springframework.web.accept")
+            |    exports("org.springframework.web.bind")
+            |    exports("org.springframework.web.bind.annotation")
+            |    exports("org.springframework.web.bind.support")
+            |    exports("org.springframework.web.client")
+            |    exports("org.springframework.web.client.support")
+            |    exports("org.springframework.web.context")
+            |    exports("org.springframework.web.context.annotation")
+            |    exports("org.springframework.web.context.request")
+            |    exports("org.springframework.web.context.request.async")
+            |    exports("org.springframework.web.context.support")
+            |    exports("org.springframework.web.cors")
+            |    exports("org.springframework.web.cors.reactive")
+            |    exports("org.springframework.web.filter")
+            |    exports("org.springframework.web.filter.reactive")
+            |    exports("org.springframework.web.jsf")
+            |    exports("org.springframework.web.jsf.el")
+            |    exports("org.springframework.web.method")
+            |    exports("org.springframework.web.method.annotation")
+            |    exports("org.springframework.web.method.support")
+            |    exports("org.springframework.web.multipart")
+            |    exports("org.springframework.web.multipart.commons")
+            |    exports("org.springframework.web.multipart.support")
+            |    exports("org.springframework.web.server")
+            |    exports("org.springframework.web.server.adapter")
+            |    exports("org.springframework.web.server.handler")
+            |    exports("org.springframework.web.server.i18n")
+            |    exports("org.springframework.web.server.session")
+            |    exports("org.springframework.web.util")
+            |    exports("org.springframework.web.util.pattern")
+            |    // ignoreServiceProvider("javax.servlet.ServletContainerInitializer")
+            |    // ignoreServiceProvider("reactor.blockhound.integration.BlockHoundIntegration")
+            |}
+            |module("org.springframework:spring-webmvc", "spring.webmvc") {
+            |    closeModule()
+            |    requiresTransitive("com.fasterxml.jackson.core")
+            |    requiresTransitive("com.fasterxml.jackson.databind")
+            |    requiresTransitive("java.desktop")
+            |    requiresTransitive("java.scripting")
+            |    requiresTransitive("java.xml")
+            |    requiresTransitive("spring.beans")
+            |    requiresTransitive("spring.context")
+            |    requiresTransitive("spring.core")
+            |    requiresTransitive("spring.jcl")
+            |    requiresTransitive("spring.web")
+            |    requires("com.fasterxml.jackson.annotation")
+            |    requires("spring.aop")
+            |    requires("spring.expression")
+            |    exports("org.springframework.web.servlet")
+            |    exports("org.springframework.web.servlet.config")
+            |    exports("org.springframework.web.servlet.config.annotation")
+            |    exports("org.springframework.web.servlet.function")
+            |    exports("org.springframework.web.servlet.function.support")
+            |    exports("org.springframework.web.servlet.handler")
+            |    exports("org.springframework.web.servlet.i18n")
+            |    exports("org.springframework.web.servlet.mvc")
+            |    exports("org.springframework.web.servlet.mvc.annotation")
+            |    exports("org.springframework.web.servlet.mvc.condition")
+            |    exports("org.springframework.web.servlet.mvc.method")
+            |    exports("org.springframework.web.servlet.mvc.method.annotation")
+            |    exports("org.springframework.web.servlet.mvc.support")
+            |    exports("org.springframework.web.servlet.resource")
+            |    exports("org.springframework.web.servlet.support")
+            |    exports("org.springframework.web.servlet.tags")
+            |    exports("org.springframework.web.servlet.tags.form")
+            |    exports("org.springframework.web.servlet.theme")
+            |    exports("org.springframework.web.servlet.view")
+            |    exports("org.springframework.web.servlet.view.document")
+            |    exports("org.springframework.web.servlet.view.feed")
+            |    exports("org.springframework.web.servlet.view.freemarker")
+            |    exports("org.springframework.web.servlet.view.groovy")
+            |    exports("org.springframework.web.servlet.view.json")
+            |    exports("org.springframework.web.servlet.view.script")
+            |    exports("org.springframework.web.servlet.view.tiles3")
+            |    exports("org.springframework.web.servlet.view.xml")
+            |    exports("org.springframework.web.servlet.view.xslt")
+            |}'''.stripMargin())
+    }
+
+}

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RequireAllDefinedDependenciesFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/RequireAllDefinedDependenciesFunctionalTest.groovy
@@ -107,16 +107,13 @@ class RequireAllDefinedDependenciesFunctionalTest extends Specification {
             
             extraJavaModuleInfo {
                 knownModule("org.jetbrains.kotlin:kotlin-stdlib", "kotlin.stdlib")
+                knownModule("org.jetbrains.kotlin:kotlin-reflect", "kotlin.reflect")
                 knownModule("net.java.dev.jna:jna", "com.sun.jna")
                 module("org.jetbrains.kotlin:kotlin-stdlib-common", "kotlin.stdlib.common") {
                     exportAllPackages()
                     requireAllDefinedDependencies()
                 }
                 module("org.jetbrains:annotations", "org.jetbrains.annotations") {
-                    exportAllPackages()
-                    requireAllDefinedDependencies()
-                }
-                module("org.jetbrains.kotlin:kotlin-reflect", "kotlin.reflect") {
                     exportAllPackages()
                     requireAllDefinedDependencies()
                 }

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/fixture/GradleBuild.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/fixture/GradleBuild.groovy
@@ -46,6 +46,10 @@ class GradleBuild {
         runner('build').buildAndFail()
     }
 
+    BuildResult task(String taskName) {
+        runner(taskName).build()
+    }
+
     GradleRunner runner(String... args) {
         if (buildFile.exists()) {
             buildFile << '\nrepositories.mavenCentral()'


### PR DESCRIPTION
Hi @jjohannes . I apologize in advance if this is a too big of a PR. I'm happy to split it into a few smaller ones; however, each commit represents a different piece of functionality so it should be easy to review/merge only portions of it.

This PR add the three new features to the plugin. 

### failOnAutomaticModules configuration

This is useful when dealing with big (10+ elements) classpath's with the goal to migrate 100% of them to be real modules. Similar to `failOnMissingModuleInfo`, this setting will fail the build if a configuration contains a JAR with an automatic module defined via the JAR Manifest.

### Allow patching real modules 

Even modular JARs may carry invalid module descriptors. For example, `org.apache.tomcat.embed:tomcat-embed-core:10.1.13` `exports` a package that does not exist (`org.apache.catalina.ssi`) in the JAR and as a result, this module cannot be used with `jlink`.

###  A new task to generate module specs (DSL?) using jdeps. 

This is similar to `requireAllDefinedDependencies()` and `exportAllPackages()`. This task uses `jdeps` under the hood so that it can infer usages of the JDK modules (e.g, `java.sql`, `java.xml`, etc) compared to just looking at the dependency metadata. It also operates on the classpath of a configuration, i.e. users will not need to define `knownModule` for the already modularized JARs.

This task requires Gradle to be powered by JDK 11+ but I made sure the other functionality of the plugin can still be used on JDK  8.  

I can open a follow-up PR to make this task compatible with Gradle JVM Toolchains if needed.



