### PR TITLE
Allow granular `exports` and `opens` declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ extraJavaModuleInfo {
     // failOnMissingModuleInfo.set(false)
     module("commons-beanutils:commons-beanutils", "org.apache.commons.beanutils") {
         exports("org.apache.commons.beanutils")
+        // or granuarly allowing access to a package by specific modules
+        // exports("org.apache.commons.beanutils", "org.mycompany.server", "org.mycompany.client")
         // exportAllPackages()
         
         requiresTransitive("org.apache.commons.logging")
@@ -78,6 +80,8 @@ extraJavaModuleInfo {
         
         // closeModule()
         // opens("org.apache.commons.beanutils")
+        // or granuarly allowing runtime-only access to a package by specific modules
+        // opens("org.apache.commons.beanutils", "org.mycompany.server", "org.mycompany.client")
         
         // requiresTransitive(...)
         // requiresStatic(...)

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
@@ -355,12 +355,16 @@ public abstract class ExtraJavaModuleInfoTransform implements TransformAction<Ex
         for (String packageName : autoExportedPackages) {
             moduleVisitor.visitExport(packageName, 0);
         }
-        for (String packageName : moduleInfo.exports) {
-            moduleVisitor.visitExport(packageName.replace('.', '/'), 0);
+        for (Map.Entry<String, Set<String>> entry : moduleInfo.exports.entrySet()) {
+            String packageName = entry.getKey();
+            Set<String> modules = entry.getValue();
+            moduleVisitor.visitExport(packageName.replace('.', '/'), 0, modules.toArray(new String[0]));
         }
 
-        for (String packageName : moduleInfo.opens) {
-            moduleVisitor.visitOpen(packageName.replace('.', '/'), 0);
+        for (Map.Entry<String, Set<String>> entry : moduleInfo.opens.entrySet()) {
+            String packageName = entry.getKey();
+            Set<String> modules = entry.getValue();
+            moduleVisitor.visitOpen(packageName.replace('.', '/'), 0, modules.toArray(new String[0]));
         }
 
         moduleVisitor.visitRequire("java.base", 0, null);

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleInfo.java
@@ -18,8 +18,7 @@ package org.gradlex.javamodule.moduleinfo;
 
 import org.gradle.api.model.ObjectFactory;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Data class to hold the information that should be added as module-info.class to an existing Jar file.
@@ -30,8 +29,8 @@ public class ModuleInfo extends ModuleSpec {
     private final String moduleVersion;
 
     boolean openModule = true;
-    final Set<String> exports = new LinkedHashSet<>();
-    final Set<String> opens = new LinkedHashSet<>();
+    final Map<String, Set<String>> exports = new LinkedHashMap<>();
+    final Map<String, Set<String>> opens = new LinkedHashMap<>();
     final Set<String> requires = new LinkedHashSet<>();
     final Set<String> requiresTransitive = new LinkedHashSet<>();
     final Set<String> requiresStatic = new LinkedHashSet<>();
@@ -58,17 +57,19 @@ public class ModuleInfo extends ModuleSpec {
      * Calling this method at least once automatically makes this a "closed" module: 'module' instead of 'open module'.
      *
      * @param opens corresponds to the directive in a 'module-info.java' file
+     * @param to modules this package should be opened to.
      */
-    public void opens(String opens) {
+    public void opens(String opens, String... to) {
         closeModule();
-        addOrThrow(this.opens, opens);
+        addOrThrow(this.opens, opens, to);
     }
 
     /**
      * @param exports corresponds to the directive in a 'module-info.java' file
+     * @param to modules this package should be exported to.
      */
-    public void exports(String exports) {
-        addOrThrow(this.exports, exports);
+    public void exports(String exports, String... to) {
+        addOrThrow(this.exports, exports, to);
     }
 
     /**
@@ -113,12 +114,6 @@ public class ModuleInfo extends ModuleSpec {
         return moduleVersion;
     }
 
-    private static void addOrThrow(Set<String> target, String element) {
-        if (!target.add(element)) {
-            throw new IllegalArgumentException("The element '" + element + "' is already specified");
-        }
-    }
-
     /**
      * Automatically export all packages of the Jar. Can be used instead of individual 'exports()' statements.
      */
@@ -138,6 +133,18 @@ public class ModuleInfo extends ModuleSpec {
      */
     public void patchRealModule() {
         this.patchRealModule = true;
+    }
+
+    private static void addOrThrow(Set<String> target, String element) {
+        if (!target.add(element)) {
+            throw new IllegalArgumentException("The element '" + element + "' is already specified");
+        }
+    }
+
+    private static void addOrThrow(Map<String, Set<String>> target, String key, String... elements) {
+        if (target.put(key, new LinkedHashSet<>(Arrays.asList(elements))) != null) {
+            throw new IllegalArgumentException("The element '" + key + "' is already specified");
+        }
     }
 
 }

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ExportsFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ExportsFunctionalTest.groovy
@@ -1,0 +1,114 @@
+package org.gradlex.javamodule.moduleinfo.test
+
+import org.gradlex.javamodule.moduleinfo.test.fixture.GradleBuild
+import org.gradlex.javamodule.moduleinfo.test.fixture.LegacyLibraries
+import spock.lang.Specification
+
+class ExportsFunctionalTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    LegacyLibraries libs = new LegacyLibraries(false)
+
+    def setup() {
+        settingsFile << 'rootProject.name = "test-project"'
+        buildFile << '''
+            plugins {
+                id("application")
+                id("org.gradlex.extra-java-module-info")
+            }
+            application {
+                mainModule.set("org.gradle.sample.app")
+                mainClass.set("org.gradle.sample.app.Main")
+            }
+        '''
+        file("src/main/java/module-info.java") << """
+            module org.gradle.sample.app {
+                requires apache.commons.collections;
+            }
+        """
+        file("src/main/java/org/gradle/sample/app/Main.java") << """
+            package org.gradle.sample.app;
+            
+            public class Main {
+                public static void main(String[] args) {                    
+                    new org.apache.commons.collections.bag.HashBag();
+                }
+            }
+        """
+    }
+
+    def "a package can be exported globally"() {
+        given:
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {                    
+                    exports("org.apache.commons.collections.bag")
+                }
+            }
+        """
+
+        expect:
+        run()
+    }
+
+    def "a package can be exported to a specific module and only to this module"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    exports("org.apache.commons.collections.bag", "org.gradle.sample.lib")
+                }
+            }
+        """
+
+        expect:
+        def out = failRun()
+        out.output.contains('package org.apache.commons.collections.bag is declared in module apache.commons.collections, which does not export it to module org.gradle.sample.app')
+    }
+
+    def "a package can be exported to a specific module"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    exports("org.apache.commons.collections.bag", "org.gradle.sample.app")
+                }
+            }
+        """
+
+        expect:
+        run()
+    }
+
+    def "a package can be exported to multiple modules"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    exports("org.apache.commons.collections.bag", "org.gradle.sample.lib", "org.gradle.sample.app")
+                }
+            }
+        """
+
+        expect:
+        run()
+    }
+
+}

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/OpensFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/OpensFunctionalTest.groovy
@@ -91,4 +91,63 @@ class OpensFunctionalTest extends Specification {
         def out = failRun()
         out.output.contains('module apache.commons.collections does not "opens org.apache.commons.collections.bag" to module org.gradle.sample.app')
     }
+
+    def "a package can be opened to a specific module"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    opens("org.apache.commons.collections.buffer", "org.gradle.sample.app")
+                    opens("org.apache.commons.collections.bag", "org.gradle.sample.app")
+                }
+            }
+        """
+
+        expect:
+        run()
+    }
+
+    def "a package can be opened to a specific module and only to this module"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    opens("org.apache.commons.collections.buffer", "org.gradle.sample.lib")
+                    opens("org.apache.commons.collections.bag", "org.gradle.sample.lib")
+                }
+            }
+        """
+
+        expect:
+        def out = failRun()
+        out.output.contains('module apache.commons.collections does not "exports org.apache.commons.collections.buffer" to module org.gradle.sample.app')
+    }
+
+    def "a package can be opened to multiple modules"() {
+        given:
+
+        buildFile << """     
+            dependencies {
+                implementation("commons-collections:commons-collections:3.2.2")
+            }             
+            extraJavaModuleInfo {
+                module(${libs.commonsCollections}, "apache.commons.collections") {
+                    opens("org.apache.commons.collections.buffer", "org.gradle.sample.lib", "org.gradle.sample.app")
+                    opens("org.apache.commons.collections.bag", "org.gradle.sample.lib", "org.gradle.sample.app")
+                }
+            }
+        """
+
+        expect:
+        run()
+    }
+
 }


### PR DESCRIPTION
This PR addressed the gap we currently have. 