### PR TITLE
Add 'failOnModifiedDerivedModuleNames' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Extra Java Module Info Gradle Plugin - Changelog
 
+# Version 1.13
+* [New] [#189](https://github.com/gradlex-org/extra-java-module-info/issues/189) - Add 'failOnModifiedDerivedModuleNames' option (Thanks to [JabRef](https://github.com/JabRef/jabref) for providing a use case)
+
 ## Version 1.12
 * [New] [#174](https://github.com/gradlex-org/extra-java-module-info/pull/174) - Add 'requiresStaticTransitive(...)' to module patch DSL
 * [New] [#172](https://github.com/gradlex-org/extra-java-module-info/pull/172) - Allow ignoring specific service provider implementations (Thanks [Ihor Herasymenko](https://github.com/iherasymenko) for contributing!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Extra Java Module Info Gradle Plugin - Changelog
 
-# Version 1.13
+## Version 1.13
 * [New] [#189](https://github.com/gradlex-org/extra-java-module-info/issues/189) - Add 'failOnModifiedDerivedModuleNames' option (Thanks to [JabRef](https://github.com/JabRef/jabref) for providing a use case)
 
 ## Version 1.12

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ plugins {
 extraJavaModuleInfo {
     // failOnMissingModuleInfo = false
     // failOnAutomaticModules = true
+    // failOnModifiedDerivedModuleNames = true
     // skipLocalJars = true
     module("commons-beanutils:commons-beanutils", "org.apache.commons.beanutils") {
         exports("org.apache.commons.beanutils")

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPlugin.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPlugin.java
@@ -74,6 +74,7 @@ public abstract class ExtraJavaModuleInfoPlugin implements Plugin<Project> {
         ExtraJavaModuleInfoPluginExtension extension = project.getExtensions().create("extraJavaModuleInfo", ExtraJavaModuleInfoPluginExtension.class);
         extension.getFailOnMissingModuleInfo().convention(true);
         extension.getFailOnAutomaticModules().convention(false);
+        extension.getFailOnModifiedDerivedModuleNames().convention(false);
         extension.getSkipLocalJars().convention(false);
         extension.getDeriveAutomaticModuleNamesFromFileNames().convention(false);
 
@@ -204,6 +205,7 @@ public abstract class ExtraJavaModuleInfoPlugin implements Plugin<Project> {
                 p.getModuleSpecs().set(extension.getModuleSpecs());
                 p.getFailOnMissingModuleInfo().set(extension.getFailOnMissingModuleInfo());
                 p.getFailOnAutomaticModules().set(extension.getFailOnAutomaticModules());
+                p.getFailOnModifiedDerivedModuleNames().set(extension.getFailOnModifiedDerivedModuleNames());
                 p.getDeriveAutomaticModuleNamesFromFileNames().set(extension.getDeriveAutomaticModuleNamesFromFileNames());
 
                 // See: https://github.com/adammurdoch/dependency-graph-as-task-inputs/blob/main/plugins/src/main/java/TestPlugin.java

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPluginExtension.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoPluginExtension.java
@@ -49,6 +49,7 @@ public abstract class ExtraJavaModuleInfoPluginExtension {
     public abstract MapProperty<String, ModuleSpec> getModuleSpecs();
     public abstract Property<Boolean> getFailOnMissingModuleInfo();
     public abstract Property<Boolean> getFailOnAutomaticModules();
+    public abstract Property<Boolean> getFailOnModifiedDerivedModuleNames();
     public abstract Property<Boolean> getSkipLocalJars();
     public abstract Property<Boolean> getDeriveAutomaticModuleNamesFromFileNames();
     public abstract Property<String> getVersionsProvidingConfiguration();

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ExtraJavaModuleInfoTransform.java
@@ -102,6 +102,9 @@ public abstract class ExtraJavaModuleInfoTransform implements TransformAction<Ex
         Property<Boolean> getFailOnAutomaticModules();
 
         @Input
+        Property<Boolean> getFailOnModifiedDerivedModuleNames();
+
+        @Input
         Property<Boolean> getDeriveAutomaticModuleNamesFromFileNames();
 
         @Input
@@ -153,6 +156,12 @@ public abstract class ExtraJavaModuleInfoTransform implements TransformAction<Ex
             String expectedName = autoModuleName(originalJar);
             if (expectedName != null && !definedName.equals(expectedName) && !moduleSpec.overrideModuleName) {
                 throw new RuntimeException("The name '" + definedName + "' is different than the Automatic-Module-Name '" + expectedName + "'; explicitly allow override via 'overrideModuleName()'");
+            }
+            if (parameters.getFailOnModifiedDerivedModuleNames().get() && !realModule && expectedName == null && !moduleSpec.overrideModuleName) {
+                String expectedAutomaticNameFromFileName = automaticModulNameFromFileName(originalJar);
+                if (!definedName.equals(expectedAutomaticNameFromFileName)) {
+                    throw new RuntimeException("The name '" + definedName + "' is different than the name derived from the Jar file name '" + expectedAutomaticNameFromFileName + "'; turn off 'failOnModifiedDerivedModuleNames' or explicitly allow override via 'overrideModuleName()'");
+                }
             }
             addModuleDescriptor(originalJar, getModuleJar(outputs, originalJar), (ModuleInfo) moduleSpec);
         } else if (moduleSpec instanceof AutomaticModuleName) {

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ForbidDerivedModuleNameChangeFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ForbidDerivedModuleNameChangeFunctionalTest.groovy
@@ -1,0 +1,75 @@
+package org.gradlex.javamodule.moduleinfo.test
+
+import org.gradlex.javamodule.moduleinfo.test.fixture.GradleBuild
+import spock.lang.Specification
+
+class ForbidDerivedModuleNameChangeFunctionalTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    def setup() {
+        settingsFile << 'rootProject.name = "test-project"'
+        buildFile << '''
+            plugins {                
+                id("org.gradlex.extra-java-module-info")
+                id("java-library")
+            }
+        '''
+        file("src/main/java/module-info.java") << '''
+            module org.gradle.sample.app {
+                requires com.vladsch.flexmark.util.misc;
+            }
+        '''
+    }
+
+    def "fails for name change if failOnModifiedDerivedModuleNames=true"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("com.vladsch.flexmark:flexmark-util-misc:0.64.8")
+            }             
+            extraJavaModuleInfo {
+                failOnModifiedDerivedModuleNames.set(true)
+                module("com.vladsch.flexmark:flexmark-util-misc", "com.vladsch.flexmark.util.misc") {}
+            }
+        '''
+
+        expect:
+        def result = fail()
+        result.output.contains("The name 'com.vladsch.flexmark.util.misc' is different than the name derived from the Jar file name 'flexmark.util.misc'; turn off 'failOnModifiedDerivedModuleNames' or explicitly allow override via 'overrideModuleName()'")
+    }
+
+    def "Allows name change if failOnModifiedDerivedModuleNames=fasle (default)"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("com.vladsch.flexmark:flexmark-util-misc:0.64.8")
+            }             
+            extraJavaModuleInfo {
+                module("com.vladsch.flexmark:flexmark-util-misc", "com.vladsch.flexmark.util.misc") {}
+            }
+        '''
+
+        expect:
+        build()
+    }
+
+    def "Allows name change via overrideModuleName"() {
+        given:
+        buildFile << ''' 
+            dependencies {
+                implementation("com.vladsch.flexmark:flexmark-util-misc:0.64.8")
+            }             
+            extraJavaModuleInfo {
+                failOnModifiedDerivedModuleNames.set(true)
+                module("com.vladsch.flexmark:flexmark-util-misc", "com.vladsch.flexmark.util.misc") {
+                    overrideModuleName()
+                }
+            }
+        '''
+
+        expect:
+        build()
+    }
+}


### PR DESCRIPTION
This option is for library developers to make sure they do not use modified names of Jars without `module-info` and without `Automatic-Module-Name`.

Motivated by this discussion: https://github.com/APIdia-net/apidia.net/issues/2#issuecomment-3048606639

TODO:
- [x] Tests: option on -> fail, option on but `overrideModuleName()` used -> no fail
- [x] Changelog