### PR TITLE
Handle classifiers in FilePathToModuleCoordinates (fixed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Extra Java Module Info Gradle Plugin - Changelog
 
+## Version 1.14.2
+* [Fixed] [#246](https://github.com/gradlex-org/extra-java-module-info/issues/246) - More correct classifier handling (fixed)
+
 ## Version 1.14.1
 * [Fixed] [#246](https://github.com/gradlex-org/extra-java-module-info/issues/246) - More correct classifier handling (Thanks to [Geolykt](https://github.com/Geolykt) for reporting)
-  * ⚠️ For matching a Jar with classifier, the _identifier_ now needs to be included - e.g. `org.dojotoolkit:dojo|distribution` instead of `org.dojotoolkit:dojo`
 
 ## Version 1.14
 * [New] [#207](https://github.com/gradlex-org/extra-java-module-info/issues/207) - Add 'exportAllPackagesExcept("org.exception", ...)' (Thanks [Tim Hurman](https://github.com/timhamoni) for contributing)

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ extraJavaModuleInfo {
     
     // when the Jar has a classifier - 'linux-x86_64' in this example:
     module("io.netty:netty-transport-native-epoll|linux-x86_64",
-           "io.netty.transport.epoll.linux.x86_64") 
-    // when you somehow cannot address a Jar via coordinates, you may use the Jar name:
+           "io.netty.transport.epoll.linux.x86_64")
+    // when there are multiple Jars and you only want to match the one without classifier
+    module("org.lwjgl:lwjgl-glfw|", "org.lwjgl.glfw")
+    // when you cannot address a Jar via coordinates, you may use the Jar name:
     module("commons-logging-1.2.jar", "org.apache.commons.loggin")
 }
 ```

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/FilePathToModuleCoordinates.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/FilePathToModuleCoordinates.java
@@ -45,7 +45,7 @@ final class FilePathToModuleCoordinates {
 
         String classifierFromGradleCache = isInGradleCache(path);
         if (classifierFromGradleCache != null) {
-            if (classifierFromGradleCache.isEmpty()) {
+            if (classifier == null) {
                 return coordinatesFromPath.equals(ga);
             }
             return coordinatesFromPath.equals(ga) && classifierFromGradleCache.equals(classifier);
@@ -53,7 +53,7 @@ final class FilePathToModuleCoordinates {
 
         String classifierFromM2Cache = isInM2Cache(path);
         if (classifierFromM2Cache != null) {
-            if (classifierFromM2Cache.isEmpty()) {
+            if (classifier == null) {
                 return coordinatesFromPath.endsWith(ga);
             }
             return coordinatesFromPath.endsWith(ga) && classifierFromM2Cache.equals(classifier);

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/IdValidator.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/IdValidator.java
@@ -5,7 +5,7 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 class IdValidator {
-    private static final String COORDINATES_PATTERN = "^[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+(\\|[a-zA-Z0-9._-]+)?$";
+    private static final String COORDINATES_PATTERN = "^[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+(\\|[a-zA-Z0-9._-]*)?$";
     private static final String FILE_NAME_PATTERN = "^[a-zA-Z0-9._-]+\\.(jar|zip)$";
 
     static void validateIdentifier(String identifier) {

--- a/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleSpec.java
+++ b/src/main/java/org/gradlex/javamodule/moduleinfo/ModuleSpec.java
@@ -33,8 +33,9 @@ public abstract class ModuleSpec implements Serializable {
         validateIdentifier(identifier);
         validateModuleName(moduleName);
         if (identifier.contains("|")) {
-            this.identifier = identifier.split("\\|")[0];
-            this.classifier = identifier.split("\\|")[1];
+            String[] split = identifier.split("\\|");
+            this.identifier = split[0];
+            this.classifier = split.length > 1 ? split[1] : "";
         } else {
             this.identifier = identifier;
             this.classifier = null;

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/FilePathToModuleCoordinatesTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/FilePathToModuleCoordinatesTest.groovy
@@ -46,7 +46,8 @@ class FilePathToModuleCoordinatesTest extends Specification {
         def path = path('/Users/jendrik/.gradle/caches/modules-2/files-2.1/org.lwjgl/lwjgl-glfw/3.3.6/399b42b491c5dfa6595ae6fd79dcba61b93538a7/lwjgl-glfw-3.3.6-natives-macos-arm64.jar')
 
         expect:
-        !gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", null)
+        !gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", "")
+        gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", null) // matches all classifiers
         gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", "natives-macos-arm64")
     }
 
@@ -95,7 +96,8 @@ class FilePathToModuleCoordinatesTest extends Specification {
         def path = path('/Users/someone/.m2/repository/org/lwjgl/lwjgl-glfw/3.3.6/lwjgl-glfw-3.3.6-natives-macos-arm64.jar')
 
         expect:
-        !gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", null)
+        !gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", "")
+        gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", null) // matches all classifiers
         gaCoordinatesFromFilePathMatch(path, "org.lwjgl:lwjgl-glfw", "natives-macos-arm64")
     }
 

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ClassifiedJarsFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/ClassifiedJarsFunctionalTest.groovy
@@ -63,6 +63,39 @@ class ClassifiedJarsFunctionalTest extends Specification {
         build().task(':compileJava').outcome == TaskOutcome.SUCCESS
     }
 
+    def "patches classified Jar if no classifier is specified"() {
+        given:
+        file("src/main/java/org/gradle/sample/app/Main.java") << """
+            package org.gradle.sample.app;
+            public class Main {
+                public static void main(String[] args) {
+                    com.sun.javafx.scene.control.ContextMenuContent menu;
+                }
+            }
+        """
+        file("src/main/java/module-info.java") << """
+            module org.gradle.sample.app {               
+                requires javafx.controls;
+            }
+        """
+        buildFile << """
+            dependencies {
+                implementation("org.openjfx:javafx-controls:11:linux")
+                implementation("org.openjfx:javafx-graphics:11:linux")
+                implementation("org.openjfx:javafx-base:11:linux")
+            }
+            extraJavaModuleInfo {
+                module("org.openjfx:javafx-controls", "javafx.controls") {
+                    preserveExisting()
+                    exports("com.sun.javafx.scene.control")
+                }
+            }
+        """
+
+        expect:
+        build().task(':compileJava').outcome == TaskOutcome.SUCCESS
+    }
+
     def "does not accidentally patch classified Jar"() {
         given:
         file("src/main/java/org/gradle/sample/app/Main.java") << """
@@ -85,11 +118,11 @@ class ClassifiedJarsFunctionalTest extends Specification {
                 implementation("org.lwjgl:lwjgl:3.2.2:natives-macos")
             }
             extraJavaModuleInfo {
-                module("org.lwjgl:lwjgl", "org.lwjgl") {
+                module("org.lwjgl:lwjgl|", "org.lwjgl") {
                     preserveExisting()
                     requiresStatic("org.lwjgl.natives")
                 }
-                module("org.lwjgl:lwjgl-glfw", "org.lwjgl.glfw") {
+                module("org.lwjgl:lwjgl-glfw|", "org.lwjgl.glfw") {
                     preserveExisting()
                     requiresStatic("org.lwjgl.glfw.natives")
                 }

--- a/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/EdgeCasesFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javamodule/moduleinfo/test/EdgeCasesFunctionalTest.groovy
@@ -74,7 +74,7 @@ class EdgeCasesFunctionalTest extends Specification {
                 failOnMissingModuleInfo.set(false)
                 automaticModule("org.apache.qpid:qpid-broker-core", "org.apache.qpid.broker") {
                     mergeJar("org.apache.qpid:qpid-broker-plugins-management-http")
-                    mergeJar("org.dojotoolkit:dojo|distribution") // This is a Zip, selected by 'distribution' classifier in dependencies of 'qpid-broker-plugins-management-http'  
+                    mergeJar("org.dojotoolkit:dojo") // This is a Zip, selected by 'distribution' classifier in dependencies of 'qpid-broker-plugins-management-http'  
                     mergeJar("org.webjars.bower:dgrid")
                     mergeJar("org.webjars.bower:dstore")
                 }


### PR DESCRIPTION
Resolves #246 

- `module("org.lwjgl:lwjgl-glfw|", "org.lwjgl.glfw")` - matches only the Jar **without** classifier (new behavior)
- `module("org.lwjgl:lwjgl-glfw", "org.lwjgl.glfw")` - matches all Jars not matched by previous rule (restores behavior of versions before 1.14.1)